### PR TITLE
Improve TaskCommand according to coding guidelines and user experience 

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -241,7 +241,7 @@ public class ParserUtil {
     private static Task parseTwoVariableTask(String taskDesc, String secondParameter) throws ParseException {
         validateTaskDescription(taskDesc);
         try {
-            TaskStatus taskStatus = TaskStatus.valueOf(secondParameter.toUpperCase().replace(" ", "_"));
+            TaskStatus taskStatus = TaskStatus.fromString(secondParameter);
             return new Task(taskDesc, taskStatus, null);
         } catch (IllegalArgumentException e) {
             try {
@@ -279,7 +279,7 @@ public class ParserUtil {
         }
 
         try {
-            TaskStatus.valueOf(taskStatusString.toUpperCase().replace(" ", "_"));
+            TaskStatus.fromString(taskStatusString);
         } catch (IllegalArgumentException e) {
             if (!errorMessage.isEmpty()) {
                 errorMessage.append("\n");
@@ -299,7 +299,7 @@ public class ParserUtil {
 
     private static TaskStatus parseTaskStatusSilently(String taskStatusString) {
         try {
-            return TaskStatus.valueOf(taskStatusString.toUpperCase().replace(" ", "_"));
+            return TaskStatus.fromString(taskStatusString);
         } catch (IllegalArgumentException e) {
             return null; // Validated earlier
         }

--- a/src/main/java/seedu/address/model/task/TaskStatus.java
+++ b/src/main/java/seedu/address/model/task/TaskStatus.java
@@ -23,7 +23,8 @@ public enum TaskStatus {
      * @throws IllegalArgumentException if the input string does not match any known task status
      */
     public static TaskStatus fromString(String str) {
-        switch (str.toLowerCase()) {
+        String normalised = str.trim().toLowerCase();
+        switch (normalised) {
         case "yet to start":
             return TaskStatus.YET_TO_START;
         case "in progress":


### PR DESCRIPTION
Fixes #166

Commit 1. Use Task.fromString() as a better practice for parsing TaskStatus
2. Improve user experience logic for taskcommand