### PR TITLE
Fix duplication error for task and updatetask commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/TaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TaskCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
@@ -59,6 +60,17 @@ public class TaskCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
+
+        List<Task> updatedTasks = new ArrayList<>(personToEdit.getTasks());
+
+        for (Task existingTask : updatedTasks) {
+            if (existingTask.getDescription().equals(task.getDescription())) {
+                throw new CommandException("This task already exists for the selected member.\n"
+                + "Task description cannot be the same!");
+            }
+        }
+        updatedTasks.add(task);
+
         Person updatedPerson = personToEdit.addTask(task);
 
         model.setPerson(personToEdit, updatedPerson);

--- a/src/main/java/seedu/address/logic/commands/TaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TaskCommand.java
@@ -65,7 +65,7 @@ public class TaskCommand extends Command {
 
         for (Task existingTask : updatedTasks) {
             if (existingTask.getDescription().equals(task.getDescription())) {
-                throw new CommandException("This task already exists for the selected member.\n"
+                throw new CommandException("This task already exists for the selected person.\n"
                 + "Task description cannot be the same!");
             }
         }

--- a/src/main/java/seedu/address/logic/commands/UpdateTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateTaskCommand.java
@@ -114,6 +114,17 @@ public class UpdateTaskCommand extends Command {
             updatedTask = updatedTask.withStatus(newStatus.get());
         }
 
+        for (int i = 0; i < tasks.size(); i++) {
+            if (i == taskIndex.getZeroBased()) continue;
+
+            Task otherTask = tasks.get(i);
+            if (newDescription.isPresent()
+                && otherTask.getDescription().equals(newDescription.get())) {
+                throw new CommandException("Such task is already present for this member.\n"
+                                            + "You cannot update to a task description that exists.\n");
+            }
+        }
+
         tasks.set(taskIndex.getZeroBased(), updatedTask);
 
         // Create a new Person with the updated tasks list.

--- a/src/main/java/seedu/address/logic/commands/UpdateTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateTaskCommand.java
@@ -115,7 +115,10 @@ public class UpdateTaskCommand extends Command {
         }
 
         for (int i = 0; i < tasks.size(); i++) {
-            if (i == taskIndex.getZeroBased()) continue;
+            //Skip the task currently updating to avoid false duplication check
+            if (i == taskIndex.getZeroBased()) {
+                continue;
+            };
 
             Task otherTask = tasks.get(i);
             if (newDescription.isPresent()

--- a/src/main/java/seedu/address/logic/commands/UpdateTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateTaskCommand.java
@@ -120,8 +120,8 @@ public class UpdateTaskCommand extends Command {
             Task otherTask = tasks.get(i);
             if (newDescription.isPresent()
                 && otherTask.getDescription().equals(newDescription.get())) {
-                throw new CommandException("Such task is already present for this member.\n"
-                                            + "You cannot update to a task description that exists.\n");
+                throw new CommandException("Such task is already present for this person.\n"
+                                            + "You cannot update to a task description that exists!\n");
             }
         }
 

--- a/src/main/java/seedu/address/logic/parser/TaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TaskCommandParser.java
@@ -9,7 +9,6 @@ import java.util.logging.Logger;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.TaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.Model;
 import seedu.address.model.task.Task;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/TaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TaskCommandParser.java
@@ -9,6 +9,7 @@ import java.util.logging.Logger;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.TaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
 import seedu.address.model.task.Task;
 
 /**
@@ -21,6 +22,8 @@ public class TaskCommandParser implements Parser<TaskCommand> {
     public TaskCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_TASK);
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TASK);
 
         Index index;
 


### PR DESCRIPTION
Fixes #178 

1. Update task/ command to verify duplicate tasks before adding. If task description already exists for this particular person, unsuccessful
2. Update updatetask command to do the same duplication check.